### PR TITLE
Linux-compliant installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a small package made for convenience in handling currencies and other figures. It's installable via:
 
 ```console
-pip install git://github.com/nikhilwoodruff/rdbl
+pip install git+http://github.com/nikhilwoodruff/rdbl.git
 ```
 
 ## Usage


### PR DESCRIPTION
Not sure if the `git://` works on other OSes, I had to use this on mine.